### PR TITLE
Add flow field drift sketch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# creative-coding-codex
+# Creative Coding Codex
+
+A collection of standalone [p5.js](https://p5js.org/) sketches. Each sketch lives in its own directory so you can tinker freely without build tooling or frameworks.
+
+## Repository layout
+
+```
+projects/
+  └── template/         # Copy this directory to start a new sketch
+```
+
+Add your own project directories under `projects/`. Each project should include at least an `index.html` that loads p5.js (via CDN or locally) and any supporting scripts, styles, or assets.
+
+## Running sketches locally
+
+Because everything is plain HTML, you can open any `index.html` file directly in your browser. For features like `fetch` or loading local assets you may prefer to run a lightweight HTTP server:
+
+```bash
+# Python 3
+python -m http.server --directory projects/<your-project>
+```
+
+Then visit `http://localhost:8000` in your browser.
+
+## Creating a new project
+
+1. Copy the starter template:
+   ```bash
+   cp -R projects/template projects/my-new-sketch
+   ```
+2. Rename the copied directory and edit its files (`index.html`, `sketch.js`, `style.css`).
+3. Update the `<title>` element and on-page copy so it describes your sketch.
+4. Start iterating!
+
+Feel free to add more HTML, JavaScript modules, or assets within your project directory as needed.

--- a/projects/flow-field/index.html
+++ b/projects/flow-field/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flow Field Drift</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Flow Field Drift</h1>
+      <p>
+        Thousands of tiny agents follow a slowly shifting vector field, fading away and
+        being reborn as their luminous trails accumulate over time.
+      </p>
+      <div class="canvas-wrapper" id="sketch-holder"></div>
+      <p class="note">Refresh to regenerate a new field.</p>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/projects/flow-field/sketch.js
+++ b/projects/flow-field/sketch.js
@@ -1,0 +1,104 @@
+const AGENT_COUNT = 900;
+const agents = [];
+const wrapMargin = 24;
+let fieldSeed;
+
+function setup() {
+  const canvasSize = Math.min(windowWidth, windowHeight) * 0.75;
+  const canvas = createCanvas(canvasSize, canvasSize);
+  canvas.parent("sketch-holder");
+  pixelDensity(1);
+  colorMode(HSB, 360, 100, 100, 1);
+  noiseDetail(4, 0.5);
+  fieldSeed = random(1000);
+
+  background(220, 70, 5);
+
+  agents.length = 0;
+  for (let i = 0; i < AGENT_COUNT; i++) {
+    agents.push(new Agent());
+  }
+}
+
+function draw() {
+  noStroke();
+  fill(220, 70, 5, 0.08);
+  rect(0, 0, width, height);
+
+  const time = fieldSeed + millis() * 0.00005;
+  for (const agent of agents) {
+    agent.step(time);
+  }
+}
+
+function windowResized() {
+  const canvasSize = Math.min(windowWidth, windowHeight) * 0.75;
+  resizeCanvas(canvasSize, canvasSize);
+  background(220, 70, 5);
+  for (const agent of agents) {
+    agent.reset();
+  }
+}
+
+class Agent {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this.pos = createVector(random(width), random(height));
+    this.prev = this.pos.copy();
+    this.heading = random(TWO_PI);
+    this.life = random(200, 360);
+    this.maxLife = this.life;
+    this.hueOffset = random(360);
+  }
+
+  step(time) {
+    this.prev.set(this.pos);
+
+    const flowAngle = sampleFlow(this.pos.x, this.pos.y, time);
+    this.heading = rotateTowards(this.heading, flowAngle, 0.15);
+
+    const speedNoise = noise(this.pos.x * 0.003, this.pos.y * 0.003, time * 0.6);
+    const speed = 0.4 + speedNoise * 2.4;
+    this.pos.x += Math.cos(this.heading) * speed;
+    this.pos.y += Math.sin(this.heading) * speed;
+
+    this.life -= 1;
+
+    const trailHue = (this.hueOffset + degrees(flowAngle) * 0.5) % 360;
+    const alpha = constrain(map(this.life, 0, this.maxLife, 0, 0.7) + 0.15, 0.05, 0.8);
+    stroke(trailHue, 70, 100, alpha);
+    strokeWeight(0.9);
+    line(this.prev.x, this.prev.y, this.pos.x, this.pos.y);
+
+    if (this.shouldRespawn()) {
+      this.reset();
+    }
+  }
+
+  shouldRespawn() {
+    return (
+      this.life <= 0 ||
+      this.pos.x < -wrapMargin ||
+      this.pos.x > width + wrapMargin ||
+      this.pos.y < -wrapMargin ||
+      this.pos.y > height + wrapMargin
+    );
+  }
+}
+
+function sampleFlow(x, y, time) {
+  const scale1 = 0.0015;
+  const scale2 = 0.0007;
+  const n1 = noise(x * scale1, y * scale1, time);
+  const n2 = noise(x * scale2 + 120, y * scale2 - 85, time * 0.6 + 50);
+  const angle = TAU * n1 + PI * (n2 - 0.5);
+  return angle;
+}
+
+function rotateTowards(current, target, amount) {
+  const difference = Math.atan2(Math.sin(target - current), Math.cos(target - current));
+  return current + difference * amount;
+}

--- a/projects/flow-field/style.css
+++ b/projects/flow-field/style.css
@@ -1,0 +1,59 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #0f172a 0%, #020617 55%, #00010b 100%);
+  color: #e2e8f0;
+}
+
+main {
+  text-align: center;
+  max-width: min(90vw, 42rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: rgba(2, 6, 23, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.5rem;
+  box-shadow: 0 2rem 4rem rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(20px);
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.note {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.canvas-wrapper {
+  position: relative;
+  margin: clamp(1.5rem, 4vw, 3rem) auto;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2),
+    0 1.5rem 3rem rgba(15, 23, 42, 0.7);
+}
+
+.canvas-wrapper canvas {
+  display: block;
+  width: min(75vmin, 720px);
+  height: auto;
+}

--- a/projects/template/index.html
+++ b/projects/template/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>p5.js Sketch Template</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main>
+      <h1>p5.js Sketch Template</h1>
+      <p>This is a minimal starting point for new sketches.</p>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/projects/template/sketch.js
+++ b/projects/template/sketch.js
@@ -1,0 +1,29 @@
+function setup() {
+  const canvasSize = Math.min(windowWidth, windowHeight) * 0.6;
+  createCanvas(canvasSize, canvasSize).parent(document.body);
+  colorMode(HSB, 360, 100, 100, 100);
+  noStroke();
+}
+
+function draw() {
+  background(210, 40, 95);
+
+  const t = millis() / 2000;
+  const layers = 12;
+
+  for (let i = 0; i < layers; i++) {
+    const angle = (TWO_PI * i) / layers + t;
+    const radius = width * 0.25 + sin(t + i) * width * 0.1;
+    const x = width / 2 + cos(angle) * radius;
+    const y = height / 2 + sin(angle) * radius;
+
+    fill((t * 60 + i * 30) % 360, 80, 100, 90);
+    const size = width * 0.12 + sin(t * 2 + i) * width * 0.05;
+    circle(x, y, size);
+  }
+}
+
+function windowResized() {
+  const canvasSize = Math.min(windowWidth, windowHeight) * 0.6;
+  resizeCanvas(canvasSize, canvasSize);
+}

--- a/projects/template/style.css
+++ b/projects/template/style.css
@@ -1,0 +1,29 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  background: radial-gradient(circle at top, #f8fafc, #d7e3fc 45%, #94a3b8);
+}
+
+main {
+  text-align: center;
+  background-color: rgba(255, 255, 255, 0.75);
+  border-radius: 1rem;
+  padding: 2rem 3rem;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.2);
+}
+
+canvas {
+  display: block;
+  margin: 2rem auto 0;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.3);
+}


### PR DESCRIPTION
## Summary
- add a Flow Field Drift project with HTML shell, description, and CDN-loaded p5.js
- implement a morphing noise-driven vector field where agents leave fading trails and respawn over time
- style the page with a dark glassmorphism treatment that frames the canvas

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0d2cfb61c83248db77970d805aa97